### PR TITLE
Out of proc emulator

### DIFF
--- a/emulator.py
+++ b/emulator.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+
+import logging
+from multiprocessing import Process, Pipe
+
+import luma.emulator.device
+import pygame
+from luma.core.render import canvas
+
+
+__EMULATOR_PROXY = None
+
+
+def get_emulator():
+    global __EMULATOR_PROXY
+    if __EMULATOR_PROXY is None:
+        __EMULATOR_PROXY = EmulatorProxy()
+    return __EMULATOR_PROXY
+
+
+class EmulatorProxy(object):
+    def __init__(self):
+        self.parent_conn, self.child_conn = Pipe()
+        self.proc = Process(target=Emulator, args=(self.child_conn,))
+        self.proc.start()
+
+    def poll_input(self, timeout=1):
+        if self.parent_conn.poll(timeout) is True:
+            return self.parent_conn.recv()
+        return None
+
+    def quit(self):
+        DummyCallableRPCObject(self.parent_conn, 'quit')()
+        self.proc.join()
+
+    def __getattr__(self, name):
+        # Raise an exception if the attribute being called
+        # Doesn't actually exist on the Emulator object
+        getattr(Emulator, name)
+        return DummyCallableRPCObject(self.parent_conn, name)
+
+
+class DummyCallableRPCObject(object):
+    def __init__(self, parent_conn, name):
+        self.parent_conn = parent_conn
+        self.name = name
+
+    def __call__(self, *args, **kwargs):
+        self.parent_conn.send({
+            'func_name': self.name,
+            'args': args,
+            'kwargs': kwargs
+        })
+
+
+class Emulator(object):
+    def __init__(self, child_conn):
+        self.child_conn = child_conn
+
+        self.char_width = 6
+        self.char_height = 8
+
+        self.cols = 128 / self.char_width
+        self.rows = 64 / self.char_height
+
+        self.cursor_enabled = False
+        self.cursor_pos = [0, 0]
+        self._quit = False
+
+        emulator_attributes = {
+            'display': 'pygame',
+            'width': 128,
+            'height': 64,
+        }
+
+        Device = getattr(luma.emulator.device, 'pygame')
+        self.device = Device(**emulator_attributes)
+
+        try:
+            self._event_loop()
+        except KeyboardInterrupt:
+            logging.info('Caught KeyboardIterrupt')
+        except:
+            logging.exception('Unknown exception during event loop')
+            raise
+        finally:
+            self.child_conn.close()
+
+    def _poll_input(self):
+        event = pygame.event.poll()
+        if event.type == pygame.KEYDOWN:
+            self.child_conn.send({'key': event.key})
+
+    def _poll_parent(self):
+        if self.child_conn.poll() is True:
+            event = self.child_conn.recv()
+            func = getattr(self, event['func_name'])
+            func(*event['args'], **event['kwargs'])
+
+    def _event_loop(self):
+        while self._quit is False:
+            self._poll_parent()
+            self._poll_input()
+
+    def setCursor(self, row, col):
+        self.cursor_pos = [
+            col * self.char_width,
+            row * self.char_height,
+        ]
+
+    def quit(self):
+        self._quit = True
+
+    def noCursor(self):
+        self.cursor_enabled = False
+
+    def cursor(self):
+        self.cursor_enabled = True
+
+    def display_data(self, *args):
+        with canvas(self.device) as draw:
+            dims = (
+                self.cursor_pos[0] - 1 + 2,
+                self.cursor_pos[1] - 1,
+                self.cursor_pos[0] + self.char_width + 2,
+                self.cursor_pos[1] + self.char_height + 1,
+            )
+
+            if self.cursor_enabled:
+                logging.debug('Drawing cursor with dims: %s', dims)
+                draw.rectangle(dims, outline='white')
+
+            args = args[:self.rows]
+            logging.debug("type(args)=%s", type(args))
+
+            for line, arg in enumerate(args):
+                logging.debug('line %s: arg=%s, type=%s', line, arg, type(arg))
+                # Emulator only:
+                # Passing anything except a string to draw.text will cause
+                # PIL to throw an exception.  Warn 'em here via the log.
+                if not isinstance(arg, basestring):
+                    logging.warning('emulator only likes strings fed to '
+                        'draw.text, prepare for exception')
+                y = (line * self.char_height - 1) if line != 0 else 0
+                draw.text((2, y), arg, fill='white')
+                logging.debug('after draw.text(2, %d), %s', y, arg)

--- a/input/drivers/pygame_input.py
+++ b/input/drivers/pygame_input.py
@@ -1,18 +1,29 @@
-import pygame
+import logging
 from time import sleep
 
+import pygame
+
+import emulator
 from skeleton import InputSkeleton
 
-used_keys = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'UP', "DOWN", "LEFT", "RIGHT", "RETURN", "PAGEUP", "PAGEDOWN"]
 
-#A dictionary to look up key names by their keycodes
-keycode_mapping = dict([(getattr(pygame, "K_"+key_name), key_name) for key_name in used_keys])
+USED_KEYS = [
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+    'UP', 'DOWN', 'LEFT', 'RIGHT', 'RETURN', 'PAGEUP', 'PAGEDOWN'
+]
+
+KEY_MAP = dict([
+    (getattr(pygame, 'K_' + key_name), key_name)
+    for key_name in USED_KEYS
+])
+
 
 class InputDevice(InputSkeleton):
     """ A driver for pygame-based keyboard key detection."""
 
     def __init__(self, path=None, name=None, **kwargs):
-        """Initialises the ``InputDevice`` object.
+        """
+        Initializes the ``InputDevice`` object.
 
         Kwargs:
 
@@ -21,27 +32,35 @@ class InputDevice(InputSkeleton):
 
         """
         InputSkeleton.__init__(self, mapping = [], **kwargs)
+        self.emulator = emulator.get_emulator()
 
     def init_hw(self):
         return True
 
     def runner(self):
-        """Blocking event loop which just calls supplied callbacks in the keymap."""
-        try:
-            while not self.stop_flag:
-                #activeevent = pygame.ACTIVEEVENT
-                #if activeevent != 1:
-                #    print(activeevent)
-                events = pygame.event.get()
-                for event in events:
-                    if event.type == pygame.KEYDOWN:
-                        if event.key in keycode_mapping:
-                            key_name = "KEY_"+keycode_mapping[event.key]
-                            if key_name == "KEY_RETURN": key_name = "KEY_ENTER"
-                            self.send_key(key_name)
-                sleep(0.01)
-        except IOError as e:
-            pass
+        """
+        Blocking event loop which just calls supplied callbacks in the keymap.
+        """
+
+        while not self.stop_flag:
+            event = self.emulator.poll_input()
+            if event is None:
+                continue
+
+            key = event['key']
+
+            if key not in KEY_MAP:
+                logging.debug('Ignoring key %s' % key)
+                continue
+
+            key_name = 'KEY_' + KEY_MAP[key]
+            if key_name == 'KEY_RETURN':
+                key_name = 'KEY_ENTER'
+            logging.debug('Mapped key %s' % key_name)
+
+            self.send_key(key_name)
+
+        self.emulator.quit()
 
     def atexit(self):
         InputSkeleton.atexit(self)

--- a/output/drivers/pygame_emulator.py
+++ b/output/drivers/pygame_emulator.py
@@ -1,14 +1,17 @@
-"""pygame emulator for lcd screen
+"""
+pygame emulator for lcd screen
 allows development of sofware on a without zerophone hardware
-e.g. on a laptop with a USB keyboard"""
+e.g. on a laptop with a USB keyboard
+"""
 
-from time import sleep
-from threading import Event
 import logging
-import pygame_emulator_factory
+from threading import Event
+from time import sleep
+
 from luma.core.render import canvas
 
-logger = logging.getLogger(__name__)
+import emulator
+
 
 class Screen():
     """
@@ -24,9 +27,6 @@ class Screen():
     methods in this class
     """
 
-    cursor_enabled = False
-    cursor_pos = (0, 0) #x, y, in characters, not pixels
-
     def __init__(self, debug=True, **kwargs):
         """ Sets variables for high-level functions.
 
@@ -37,29 +37,21 @@ class Screen():
            * ``debug`` (default=False): debug mode which prints out the commands sent to display
            * ``**kwargs``: all the other arguments
                  get passed to the init_display() function (currently ignored)"""
-
-        logger.debug("entering Screen constructor, kwargs = %s", kwargs)
-        self.busy_flag = Event()
-        #TODO: this needs to be adjusted based on window/screen size
-        self.charwidth = 6
-        self.charheight = 8
-        self.cols = 128/self.charwidth
-        self.rows = 64/self.charheight
-        #with the default 128 pixels wide and 64 pixels high screen
-        #implicitly required for the splash screen, this works
-        #out to be 18 columns wide by 8 rows high
-        logger.debug("cols = %d, rows = %d", self.cols, self.rows)
         self.debug = debug
+        self.char_width = 6
+        self.char_height = 8
+        self.cols = 128 / self.char_width
+        self.rows = 64 / self.char_height
+
         self.init_display(**kwargs)
 
     def init_display(self):
-        """Creates instance of pygame emulator device and stores it in a member variable. """
-        logger.debug("entered pygame_emulator.init_display")
-        #note: although the emulator factory allows passing the constructor a width
-        #and height, if anything but 128 x 64 is used, it will cause the splash screen
-        #to throw an exception.
-        self.device = pygame_emulator_factory.get_pygame_emulator_device()
-        logger.debug("set device")
+        """
+        Creates subprocess of a of pygame emulator device
+        """
+
+        logging.debug('Creating emulator instance')
+        self.emulator = emulator.get_emulator()
 
     def display_data(self, *args):
         """Displays data on display.
@@ -71,49 +63,18 @@ class Screen():
                   Note:  the emulator does not support passing tuples, lists
                   or anything except comma delimited simple strings as args.
         """
-        logger.debug("entered display_data with args = %s.  args type is %s", args, type(args))
-        while self.busy_flag.isSet():
-            sleep(0.01)
-        self.busy_flag.set()
-        args = args[:self.rows]
-        with canvas(self.device) as draw:
-            if self.cursor_enabled:
-                dims = (self.cursor_pos[0]-1+2,
-                        self.cursor_pos[1]-1,
-                        self.cursor_pos[0]+self.charwidth+2,
-                        self.cursor_pos[1]+self.charheight+1)
-                draw.rectangle(dims, outline="white")
-                logger.debug("cursor enabled.  after draw.rectangle with corners: %s", dims)
-            else:
-                logger.debug("cursor disabled")
-
-            logger.debug("type(args)=%s", type(args))
-            for line, arg in enumerate(args):
-                logger.debug("line = %s, arg = %s, type(arg)=%s", line, arg, type(arg))
-                #Emulator only:  Passing anything except a string to draw.text will cause PIL to
-                #throw an exception.  Warn 'em here via the log.
-                if not isinstance(arg, basestring):
-                    logger.warning(
-                        "emulator only likes strings fed to draw.text, prepare for exception")
-                y = (line*self.charheight - 1) if line != 0 else 0
-                draw.text((2, y), arg, fill="white")
-                logger.debug("after draw.text(2,%d), %s", y, arg)
-
-        self.busy_flag.clear()
+        self.emulator.display_data(*args)
 
     def setCursor(self, row, col):
         """
         Called from menu.py refresh() so don't remove this method
         Set current input cursor to ``row`` and ``column`` specified """
-        logger.debug("setCursor entered.  row=%d, col=%d", row, col)
-        self.cursor_pos = (col*self.charwidth, row*self.charheight)
+        self.emulator.setCursor(row, col)
 
     def noCursor(self):
         """ Turns the underline cursor off """
-        logger.debug("noCursor called")
-        self.cursor_enabled = False
+        self.emulator.noCursor()
 
     def cursor(self):
         """ Turns the underline cursor on """
-        logger.debug("cursor called")
-        self.cursor_enabled = True
+        self.emulator.cursor()

--- a/splash.py
+++ b/splash.py
@@ -6,6 +6,11 @@ from time import sleep
 def splash(i, o):
     image = PIL.Image.open("splash.png").convert('L')
     image = invert(image)
-    image = image.convert(o.device.mode)
-    o.device.display(image)
+    #FIXME:
+    # need a first-class API call on the display to do this
+    # Moving the emulator out of proc broke this feature (can't access
+    # the 'device' property anymore
+
+#    image = image.convert(o.device.mode)
+#    o.device.display(image)
 

--- a/splash.py
+++ b/splash.py
@@ -6,11 +6,11 @@ from time import sleep
 def splash(i, o):
     image = PIL.Image.open("splash.png").convert('L')
     image = invert(image)
+
     #FIXME:
-    # need a first-class API call on the display to do this
+    # need a first-class API call on the display to do this properly
     # Moving the emulator out of proc broke this feature (can't access
-    # the 'device' property anymore
-
-#    image = image.convert(o.device.mode)
-#    o.device.display(image)
-
+    # the 'device' property anymore)
+    if hasattr(o, "device"):
+        image = image.convert(o.device.mode)
+        o.device.display(image)


### PR DESCRIPTION
This pull request moves the emulator to it's own process to address #10. 

It polls the parent process for output and the parent process polls it for input. There's a singleton so that both the output and input drivers can access the same same emulator.

I also refactored main.py while maintaining the same overall functionality, and introduced logging as a first-class feature to aid in debugging (both as a rotating log file and in stdout). I found this to be very useful while implementing the core emulator out of proc feature.